### PR TITLE
Fix output mask redundant dims

### DIFF
--- a/birefnetNode.py
+++ b/birefnetNode.py
@@ -204,9 +204,6 @@ class RembgByBiRefNet:
         out_images = torch.cat(_images, dim=0)
         out_masks = torch.cat(_masks, dim=0)
 
-        if out_masks.shape[0] == 1:
-            out_masks = out_masks.squeeze(0)
-
         return out_images, out_masks
 
 

--- a/birefnetNode.py
+++ b/birefnetNode.py
@@ -199,10 +199,13 @@ class RembgByBiRefNet:
             image = apply_mask_to_image(image.cpu(), mask.cpu())
 
             _images.append(image)
-            _masks.append(mask)
+            _masks.append(mask.squeeze(0))
 
         out_images = torch.cat(_images, dim=0)
         out_masks = torch.cat(_masks, dim=0)
+
+        if out_masks.shape[0] == 1:
+            out_masks = out_masks.squeeze(0)
 
         return out_images, out_masks
 


### PR DESCRIPTION
Output masks in more "comfy-compatible" way, so more nodes can use them.

Returns [h,w] if mask batch is 1
Returns [b,h,w] if mask batch is more than 1